### PR TITLE
Refactor dup function to retrieve domains from cert

### DIFF
--- a/danectl
+++ b/danectl
@@ -810,9 +810,8 @@ new()
 dup()
 {
 	certname="$1"
-	domains="$*"
 	certname="$(echo "$certname" | sed 's/ .*$//')"
-	domains="$(echo "$domains" | sed 's/ /,/g')"
+	domains=$(openssl x509 -in /etc/letsencrypt/live/mail.proteamail.com-rsa/cert.pem -noout -text | grep -A1 "Subject Alternative Name" | tail -1 | sed 's/.*DNS://' | sed 's/, DNS:/,/g' | tr -d ' ')
 	[ ! -d "$le/live/$certname" ] && die "dup $certname: Failed to find live original $certname"
 	[ ! -d "$le/current/$certname" ] && die "dup $certname: Failed to find current original $certname"
 	[ -d "$le/live/$certname-duplicate" ] && die "dup $certname: Duplicate $certname-duplicate already exists"


### PR DESCRIPTION
This PR hopes to fix issue #15.

In the `dup` function:

Retrieve the domain name(s) from the actual certificate via `openssl`, rather than presuming it/they can be found in the Certificate Name (`certbot` also does not use the Certificate Name for this).

This prevents an error in the `danectl dup` function when a certificate name does not correspond to a valid (or correct) domain name, e.g when the name is mail.domain.tld-rsa.